### PR TITLE
Allow neater output when using `puts`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ array is a list which organizes items by linear sequence. But types of items can
 map is treated as `key-value` container. please attention to that only `boolean`, `int` and `string` types can be used as key.
 
 ```
->>> let a = {"name":"monkey", true:1, 7:"sevent"};
+>>> let a = {"name":"monkey", true:1, 7:"seven"};
 >>> a
 {name: monkey, true: 1, 7: seven}
 >>> a["name"]

--- a/README.md
+++ b/README.md
@@ -152,6 +152,13 @@ Hello, world
 4950
 ```
 
+## 2.7 Comments
+
+`monkey` support two kinds of comments:
+
+* Comments beginning with `//` last until the following newline.
+* Comments between `/*` and `*/` may span multiple lines.
+
 
 # 3 Extensions
 To make `monkey` interpreter language to be more powerfull, it is deserved improving it.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Monkey
-A interpreter language implementation in Go 
+A interpreter language implementation in Go
 
 # 1 Introduction
-[Write an Interpreter in Go](https://interpreterbook.com) source code. 
+[Write an Interpreter in Go](https://interpreterbook.com) source code.
 
 [中文翻译](book/README.md)
 
@@ -14,7 +14,7 @@ Hello $Username! This is Monkey programming language!
 Feel free to type in commnd
 Enter "exit()" or CTRL+C to quit command interface
 >>>
-``` 
+```
 
 # 2 Syntax
 
@@ -37,24 +37,24 @@ using `let` as keyword, each line ends with `;`.
 4.2
 >>> a - b
 1.8
->>> a * b 
+>>> a * b
 3.6
->>> a / b 
+>>> a / b
 2.5
 ```
 
 ## 2.3 Builtin containers
-`monkey` contains two builtin containers: `array` and `map`. 
+`monkey` contains two builtin containers: `array` and `map`.
 - array
 
 array is a list which organizes items by linear sequence. But types of items can be different from each other.
 
 ```
 >>> let a = [1, 2.3, "array"];
->>> a 
+>>> a
 [1, 2.3, array]
 >>> let b = push(a, "another");
->>> b 
+>>> b
 [1, 2.3, array, another]
 ```
 
@@ -73,7 +73,7 @@ monkey
 >> a[7]
 seven
 >>>let b = set(a, 8, "eight");
->>> b 
+>>> b
 {name: moneky, true: 1, 7: sevent, 8: eight}
 ```
 
@@ -107,6 +107,11 @@ insert key value pair into the map
 
 print literal value of objects.
 
+- `type`
+
+returns the type of a variable.
+
+
 
 ## 2.5 Function
 
@@ -120,6 +125,13 @@ print literal value of objects.
 >>>addTwo(1,2, add)
 5
 ```
+
+It is also possible to define a function without using `let` via the `function` keyword:
+
+>>>function hello() { puts "Hello, world" ; };
+>>> hello()
+Hello, world
+
 
 ## 2.5 If-else statements
 
@@ -148,4 +160,4 @@ To make `monkey` interpreter language to be more powerfull, it is deserved impro
 - [x] unicode literal
 - [x] loop branch
 - [ ] translate into Chinese
-- [ ] ... 
+- [ ] ...

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ array is a list which organizes items by linear sequence. But types of items can
 map is treated as `key-value` container. please attention to that only `boolean`, `int` and `string` types can be used as key.
 
 ```
->>> let a = {"name":"moneky", true:1, 7:"sevent"};
+>>> let a = {"name":"monkey", true:1, 7:"sevent"};
 >>> a
 {name: monkey, true: 1, 7: seven}
 >>> a["name"]

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -242,6 +242,31 @@ func (fl *FunctionLiteral) String() string {
 
 }
 
+type FunctionDefineLiteral struct {
+	Token      token.Token
+	Parameters []*Identifier
+	Body       *BlockStatement
+}
+
+func (fl *FunctionDefineLiteral) expressionNode() {}
+func (fl *FunctionDefineLiteral) TokenLiteral() string {
+	return fl.Token.Literal
+}
+func (fl *FunctionDefineLiteral) String() string {
+	var out bytes.Buffer
+	params := make([]string, 0)
+	for _, p := range fl.Parameters {
+		params = append(params, p.String())
+	}
+	out.WriteString(fl.TokenLiteral())
+	out.WriteString("(")
+	out.WriteString(strings.Join(params, ", "))
+	out.WriteString(") ")
+	out.WriteString(fl.Body.String())
+	return out.String()
+
+}
+
 type CallExpression struct {
 	Token     token.Token
 	Function  Expression

--- a/evaluator/builtins.go
+++ b/evaluator/builtins.go
@@ -128,7 +128,7 @@ var builtins = map[string]*object.Builtin{
 	"puts": {
 		Fn: func(args ...object.Object) object.Object {
 			for _, arg := range args {
-				fmt.Println(arg.Inspect())
+				fmt.Print(arg.Inspect())
 			}
 			return NULL
 		},

--- a/evaluator/builtins.go
+++ b/evaluator/builtins.go
@@ -133,4 +133,31 @@ var builtins = map[string]*object.Builtin{
 			return NULL
 		},
 	},
+	"type": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return newError("wrong number of arguments. got=%d, want=1",
+					len(args))
+			}
+			switch args[0].(type) {
+			case *object.String:
+				return &object.String{Value: "string"}
+			case *object.Boolean:
+				return &object.String{Value: "bool"}
+			case *object.Array:
+				return &object.String{Value: "array"}
+			case *object.Function:
+				return &object.String{Value: "function"}
+			case *object.Integer:
+				return &object.String{Value: "integer"}
+			case *object.Float:
+				return &object.String{Value: "float"}
+			case *object.Hash:
+				return &object.String{Value: "hash"}
+			default:
+				return newError("argument to `type` not supported, got=%s",
+					args[0].Type())
+			}
+		},
+	},
 }

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -12,6 +12,7 @@ var (
 	TRUE  = &object.Boolean{Value: true}
 	FALSE = &object.Boolean{Value: false}
 )
+
 // Eval: entry point of environment
 func Eval(node ast.Node, env *object.Environment) object.Object {
 	switch node := node.(type) {
@@ -63,6 +64,7 @@ func Eval(node ast.Node, env *object.Environment) object.Object {
 			return val
 		}
 		env.Set(node.Name.Value, val)
+		return val
 	case *ast.Identifier:
 		return evalIdentifier(node, env)
 	case *ast.FunctionLiteral:
@@ -399,6 +401,8 @@ func evalIndexExpression(left, index object.Object) object.Object {
 		return evalArrayIndexExpression(left, index)
 	case left.Type() == object.HASH_OBJ:
 		return evalHashIndexExpression(left, index)
+	case left.Type() == object.STRING_OBJ:
+		return evalStringIndexExpression(left, index)
 	default:
 		return newError("index operator not support:%s", left.Type())
 
@@ -425,6 +429,16 @@ func evalHashIndexExpression(hash, index object.Object) object.Object {
 		return NULL
 	}
 	return pair.Value
+}
+
+func evalStringIndexExpression(input, index object.Object) object.Object {
+	str := input.(*object.String).Value
+	idx := index.(*object.Integer).Value
+	max := int64(len(str))
+	if idx < 0 || idx > max {
+		return NULL
+	}
+	return &object.String{Value: string(str[idx])}
 }
 
 func evalHashLiteral(node *ast.HashLiteral, env *object.Environment) object.Object {

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -71,6 +71,11 @@ func Eval(node ast.Node, env *object.Environment) object.Object {
 		params := node.Parameters
 		body := node.Body
 		return &object.Function{Parameters: params, Env: env, Body: body}
+	case *ast.FunctionDefineLiteral:
+		params := node.Parameters
+		body := node.Body
+		env.Set(node.TokenLiteral(), &object.Function{Parameters: params, Env: env, Body: body})
+		return NULL
 	case *ast.CallExpression:
 		function := Eval(node.Function, env)
 		if isError(function) {

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -87,6 +87,19 @@ func testFloatObject(t *testing.T, obj object.Object, expected float64) bool {
 	}
 	return true
 }
+func testStringObject(t *testing.T, obj object.Object, expected string) bool {
+	result, ok := obj.(*object.String)
+	if !ok {
+		t.Errorf("obj is not String. got=%T(%+v)", obj, obj)
+		return false
+	}
+	if result.Value != expected {
+		t.Errorf("object has wrong value. got=%s, want=%s",
+			result.Value, expected)
+		return false
+	}
+	return true
+}
 
 func TestEvalBooleanExpression(t *testing.T) {
 	tests := []struct {
@@ -209,9 +222,9 @@ func TestErrorHandling(t *testing.T) {
 		{"true+false", "unknown operator: BOOLEAN + BOOLEAN"},
 		{"5;true+false;5", "unknown operator: BOOLEAN + BOOLEAN"},
 		{"if (10>1) { true+false;}", "unknown operator: BOOLEAN + BOOLEAN"},
-		{`if (10 > 1) { 
+		{`if (10 > 1) {
       if (10>1) {
-			return true+false;	
+			return true+false;
 			}
 			return 1;
 }`, "unknown operator: BOOLEAN + BOOLEAN"},
@@ -410,6 +423,35 @@ func TestArrayIndexExpression(t *testing.T) {
 	}
 }
 
+func TestStringIndexExpression(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected interface{}
+	}{
+		{
+			"\"Steve\"[0]",
+			"S",
+		},
+		{
+			"\"Steve\"[1]",
+			"t",
+		},
+		{
+			"\"Steve\"[101]",
+			nil,
+		},
+	}
+	for _, tt := range tests {
+		evaluated := testEval(tt.input)
+
+		str, ok := tt.expected.(string)
+		if ok {
+			testStringObject(t, evaluated, str)
+		} else {
+			testNullObject(t, evaluated)
+		}
+	}
+}
 func TestHashLiterals(t *testing.T) {
 	input := `let two="two";
 	{

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -548,3 +548,41 @@ sum
 	evaluated := testEval(input)
 	testDecimalObject(t, evaluated, 4950)
 }
+
+func TestTypeBuiltin(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected interface{}
+	}{
+		{
+			"type( \"Steve\" );",
+			"string",
+		},
+		{
+			"type( 1 );",
+			"integer",
+		},
+		{
+			"type( 3.14159 );",
+			"float",
+		},
+		{
+			"type( [1,2,3] );",
+			"array",
+		},
+		{
+			"type( { \"name\":\"monkey\", true:1, 7:\"sevent\"} );",
+			"hash",
+		},
+	}
+	for _, tt := range tests {
+		evaluated := testEval(tt.input)
+
+		str, ok := tt.expected.(string)
+		if ok {
+			testStringObject(t, evaluated, str)
+		} else {
+			testNullObject(t, evaluated)
+		}
+	}
+}

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -2,6 +2,7 @@ package lexer
 
 import (
 	"monkey/token"
+	"strings"
 )
 
 // Lexer used to be as lexer for monkey programming language.
@@ -187,7 +188,13 @@ func (l *Lexer) readString() string {
 			break
 		}
 	}
-	return string(l.characters[position:l.position])
+	out := string(l.characters[position:l.position])
+
+	// Expand newlines, linefeeds, and tabs
+	out = strings.Replace(out, `\n`, "\n", -1)
+	out = strings.Replace(out, `\r`, "\r", -1)
+	out = strings.Replace(out, `\t`, "\t", -1)
+	return out
 }
 
 // peek character

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -41,7 +41,7 @@ let add = fn(x, y){
   x+y;
 };
 let result = add(five, ten);
-!-/*5;
+!-/ *5;
 5<10>5;
 
 if(5<10){
@@ -187,5 +187,66 @@ func TestUnicodeLexer(t *testing.T) {
 	}
 	if tok.Literal != "世界" {
 		t.Fatalf("token literal wrong, expected=%q, got=%q", "世界", tok.Literal)
+	}
+}
+
+func TestSimpleComment(t *testing.T) {
+	input := `=+// This is a comment
+let a = 1;`
+
+	tests := []struct {
+		expectedType    token.TokenType
+		expectedLiteral string
+	}{
+		{token.ASSIGN, "="},
+		{token.PLUS, "+"},
+		{token.LET, "let"},
+		{token.IDENT, "a"},
+		{token.ASSIGN, "="},
+		{token.INT, "1"},
+		{token.SEMICOLON, ";"},
+		{token.EOF, ""},
+	}
+	l := New(input)
+	for i, tt := range tests {
+		tok := l.NextToken()
+		if tok.Type != tt.expectedType {
+			t.Fatalf("tests[%d] - tokentype wrong, expected=%q, got=%q", i, tt.expectedType, tok.Type)
+		}
+		if tok.Literal != tt.expectedLiteral {
+			t.Fatalf("tests[%d] - Literal wrong, expected=%q, got=%q", i, tt.expectedLiteral, tok.Literal)
+		}
+	}
+}
+
+func TestMultiLineComment(t *testing.T) {
+	input := `=+/* This is a comment
+
+We're still in a comment
+let c = 2; */
+let a = 1;`
+
+	tests := []struct {
+		expectedType    token.TokenType
+		expectedLiteral string
+	}{
+		{token.ASSIGN, "="},
+		{token.PLUS, "+"},
+		{token.LET, "let"},
+		{token.IDENT, "a"},
+		{token.ASSIGN, "="},
+		{token.INT, "1"},
+		{token.SEMICOLON, ";"},
+		{token.EOF, ""},
+	}
+	l := New(input)
+	for i, tt := range tests {
+		tok := l.NextToken()
+		if tok.Type != tt.expectedType {
+			t.Fatalf("tests[%d] - tokentype wrong, expected=%q, got=%q", i, tt.expectedType, tok.Type)
+		}
+		if tok.Literal != tt.expectedLiteral {
+			t.Fatalf("tests[%d] - Literal wrong, expected=%q, got=%q", i, tt.expectedLiteral, tok.Literal)
+		}
 	}
 }

--- a/token/token.go
+++ b/token/token.go
@@ -11,51 +11,53 @@ type Token struct {
 
 // pre-defined TokenType
 const (
-	ILLEGAL   = "ILLEGAL"
-	EOF       = "EOF"
-	IDENT     = "IDENT"
-	INT       = "INT"
-	FLOAT     = "FLOAT"
-	ASSIGN    = "="
-	PLUS      = "+"
-	COMMA     = ","
-	SEMICOLON = ";"
-	MINUS     = "-"
-	BANG      = "!"
-	ASTERISK  = "*"
-	SLASH     = "/"
-	LT        = "<"
-	GT        = ">"
-	LPAREN    = "("
-	RPAREN    = ")"
-	LBRACE    = "{"
-	RBRACE    = "}"
-	FUNCTION  = "FUNCTION"
-	LET       = "LET"
-	TRUE      = "TRUE"
-	FALSE     = "FALSE"
-	IF        = "IF"
-	ELSE      = "ELSE"
-	RETURN    = "RETURN"
-	FOR       = "FOR"
-	EQ        = "=="
-	NOT_EQ    = "!="
-	STRING    = "STRING"
-	LBRACKET  = "["
-	RBRACKET  = "]"
-	COLON     = ":"
+	ILLEGAL         = "ILLEGAL"
+	EOF             = "EOF"
+	IDENT           = "IDENT"
+	INT             = "INT"
+	FLOAT           = "FLOAT"
+	ASSIGN          = "="
+	PLUS            = "+"
+	COMMA           = ","
+	SEMICOLON       = ";"
+	MINUS           = "-"
+	BANG            = "!"
+	ASTERISK        = "*"
+	SLASH           = "/"
+	LT              = "<"
+	GT              = ">"
+	LPAREN          = "("
+	RPAREN          = ")"
+	LBRACE          = "{"
+	RBRACE          = "}"
+	FUNCTION        = "FUNCTION"
+	DEFINE_FUNCTION = "DEFINE_FUNCTION"
+	LET             = "LET"
+	TRUE            = "TRUE"
+	FALSE           = "FALSE"
+	IF              = "IF"
+	ELSE            = "ELSE"
+	RETURN          = "RETURN"
+	FOR             = "FOR"
+	EQ              = "=="
+	NOT_EQ          = "!="
+	STRING          = "STRING"
+	LBRACKET        = "["
+	RBRACKET        = "]"
+	COLON           = ":"
 )
 
 // reversed keywords
 var keywords = map[string]TokenType{
-	"fn":     FUNCTION,
-	"let":    LET,
-	"true":   TRUE,
-	"false":  FALSE,
-	"if":     IF,
-	"else":   ELSE,
-	"return": RETURN,
-	"for":    FOR,
+	"fn":       FUNCTION,
+	"function": DEFINE_FUNCTION,
+	"let":      LET,
+	"true":     TRUE,
+	"false":    FALSE,
+	"if":       IF,
+	"else":     ELSE,
+	"return":   RETURN,
+	"for":      FOR,
 }
 
 // LookupIdentifier used to determinate whether identifier is keyword nor not


### PR DESCRIPTION
The puts function accepts an array of things to print, but it
prints them separated via a newline.  This makes it hard to output
human-readable text.

For example:

    frodo ~/src/monkey $ ./monkey
    Hello skx! This is the Monkey programming language!
    Feel free to type in command
    Enter "exit()" or CTRL+C to quit command interface
    >>puts( "This", " is" , "a test" );
    This
     is
    a test
    null

This pull-request makes two changes:

* Switches the output of the `puts` function to use `fmt.Print` instead
  of `fmt.Println`.  This removes the extra newline.
* Allows the string type to convert "\n" into a newline.
  * Also handled line-feed + tab too.

With this pull-request merged the following is possible:

    frodo ~/src/monkey $ ./monkey
    Hello skx! This is the Monkey programming language!
    Feel free to type in command
    Enter "exit()" or CTRL+C to quit command interface
    >>let a = 33;
    >>puts( "The value is " , a, "\n" );
    The value is 33
    null